### PR TITLE
要約の140字制限と遊びレコメンドの評価関数のパラメータ変更

### DIFF
--- a/ml_models/extractive_summarization/extractive_summarization.py
+++ b/ml_models/extractive_summarization/extractive_summarization.py
@@ -17,11 +17,25 @@ from sumy.summarizers.lex_rank import LexRankSummarizer
 
 
 # main
-def preprocessed_lexrank(text, sum_count=3):
+def preprocessed_lexrank(text, sum_count):
     sentences = separate_sentences(text)
     sentences_dc = dc.data_cleaning(sentences)
     sentence_words = separate_words(sentences_dc)
-    return summy_test(sentences, sentence_words, sum_count=sum_count)
+    if sum_count != 0:
+        return sum_text(sentences, sentence_words, sum_count=sum_count)
+    if sum_count == 0:
+        num, stock = 2, 0
+        while 1:
+            targ = sum_text(sentences, sentence_words, sum_count=num)
+            if (len(targ) > 140) and (num == 2) :
+                return sum_text(sentences, sentence_words, sum_count=1)
+            elif len(targ) < 140 : 
+                stock = targ
+                num += 1
+            elif len(targ) > 140:
+                return stock
+            else:
+                return "unanticipated process"
 
 
 # 文区切り
@@ -63,7 +77,7 @@ def separate_words(sentences):
     
     
 # 文章要約メソッド
-def summy_test(sentences_org, corpus, sum_count):
+def sum_text(sentences_org, corpus, sum_count):
     sentences = [' '.join(sentence) + u'。' for sentence in corpus]
     for i, sentence in enumerate(sentences):
         sentences[i] = sentence.strip() # 前後の空白を削除(先頭に英単語があると空白が入ってエラーが出る)

--- a/ml_models/recommendation_models/fun_recommendation.py
+++ b/ml_models/recommendation_models/fun_recommendation.py
@@ -70,7 +70,7 @@ def _calc_eval_vals(y_pred):
     variation = y_pred["95%"] - y_pred["5%"]
     variation_mm = _calc_minmaxscaler(variation)
     
-    A = 0.6
+    A = 0.4
     B = 1 - A
     # 期待値が高く,ばらつきが大きい(今までに経験してない)遊びをレコメンドしたい気持ちが込められてる
     eval_vals = A * expected_value_mm + B * variation_mm

--- a/view/flock_view/pages/articles/new.vue
+++ b/view/flock_view/pages/articles/new.vue
@@ -93,7 +93,7 @@ import Summary from '../../components/Summary.vue'
         // 要約
         const summaryUrl = this.$summaryBaseUrl + "/summary/"
         var summaryParams = { 
-          "sum_count": 3,
+          "sum_count": 0,
           "text": this.body
         }
         axios.post(summaryUrl, summaryParams)


### PR DESCRIPTION
# やったこと
- 要約に140字の制限をつけた
- あそびレコメンドが局所解に陥るので，分散の項に対する重みを増やした