### PR TITLE
『あ』とかを入れると要約が返ってこなくなるバグの修正

### DIFF
--- a/ml_models/extractive_summarization/extractive_summarization.py
+++ b/ml_models/extractive_summarization/extractive_summarization.py
@@ -21,29 +21,7 @@ def preprocessed_lexrank(text, sum_count):
     sentences = separate_sentences(text)
     sentences_dc = dc.data_cleaning(sentences)
     sentence_words = separate_words(sentences_dc)
-    if sum_count != 0:
-        return sum_text(sentences, sentence_words, sum_count=sum_count)
-    if sum_count == 0:
-        count = 0
-        num, stock = 2, 0
-        while count < 10:
-            targ = sum_text(sentences, sentence_words, sum_count=num)
-            if (len(targ) > 140) and (num == 2) : # 2文の時点で140字を超えた場合
-                return sum_text(sentences, sentence_words, sum_count=1)
-            elif len(targ) < 140 : # ある時点で140字未満の場合
-                stock = targ
-                num += 1
-            elif len(targ) > 140: # ある時点で140字を超えた場合
-                return stock
-            elif num == 10 # MAX10文まで
-                return stock
-            elif len(targ) == 0: # 『あ』みたいな文に対応させる
-                return "要約を手動で編集してください！ごめんなさい！"
-            else: # 予期せぬ事態に備えて
-                return "要約を手動で編集してください！ごめんなさい！"
-            count += 1
-        return "要約を手動で編集してください！ごめんなさい！" # 予期せぬ事態に備えて
-
+    return get_sum_text(sentences, sentence_words, sum_count)
 
 # 文区切り
 def separate_sentences(text):
@@ -101,3 +79,29 @@ def sum_text(sentences_org, corpus, sum_count):
         b.append(sentences_org[sentences.index("{}".format(sentence.__str__()))])
         b.append("\n")
     return "".join(b)
+
+
+# 文字数制限付きの文章要約
+def get_sum_text(sentences, sentence_words, sum_count):
+    if sum_count != 0:
+        return sum_text(sentences, sentence_words, sum_count=sum_count)
+    if sum_count == 0:
+        counter = 0
+        num, stock = 1, ''
+        while counter < 20:
+            targ = sum_text(sentences, sentence_words, sum_count=num)
+            if (len(targ) >= 140) and (num == 1) : 
+                # 要約文が1文の時点で140字以上250字未満の場合
+                return targ if (len(targ) < 250) else "要約文(1文)が長すぎました！手動で編集してください！ごめんなさい！"
+            elif (len(targ) > 140) or (num > 15) or (stock.count('\n') == targ.count('\n')):
+                # 要約文が140字を超えた場合 or 要約が15文以上の場合 or 前回と今回で要約文の文数が増えない場合
+                return stock
+            elif len(targ) <= 140 : 
+                # 要約文が140字以下の場合
+                stock = targ
+                num += 1
+            else: 
+                # 予期せぬ事態に備えて
+                return "予期せぬ文章です！要約を手動で編集してください！ごめんなさい！"
+            counter += 1
+        return "要約を手動で編集してください！ごめんなさい！" 


### PR DESCRIPTION
# やったこと
- 要約文が1文の時，それが140字以上250字未満の場合に要約文が返るようにした
- 『あ』などの意味のない文は，そのまま返すようにした
- 短い文が大量に入った時のために，15文以下となるような制約を追加した
- 全文が短く文数も少ない入力の時のために，前回と今回の要約の文数が同じの時にその要約文が返るようにした